### PR TITLE
Added stress test, clean up code of linter complaints, fixed a bug

### DIFF
--- a/helpers.go
+++ b/helpers.go
@@ -10,6 +10,7 @@ import (
 	logger "github.com/nic0lae/golog"
 )
 
+// GetRandomNumber returns an int 0 to boudary-1
 func GetRandomNumber(boundary int) int {
 	s1 := rand.NewSource(time.Now().UnixNano())
 	r1 := rand.New(s1)
@@ -18,7 +19,7 @@ func GetRandomNumber(boundary int) int {
 
 func getDictKeysAsList() []string {
 	keys := make([]string, 0)
-	for k, _ := range getNodes() {
+	for k := range getNodes() {
 		keys = append(keys, k)
 	}
 
@@ -64,7 +65,6 @@ func sendRandomTransactionWithTime(fromWallet string, toWallet string, transacti
 		fromWallet,
 	}
 
-
 	go func() {
 		logger.Instance().LogInfo(
 			GlobalLogTag, 0,
@@ -86,8 +86,8 @@ var once sync.Once
 
 var startingBalance = 10000000
 
+// CreateNodeAndAddToList creates node and add to the list
 func CreateNodeAndAddToList(newMember string) {
-
 	GenesisBlock := Block{
 		Prev: nil,
 		Next: nil,

--- a/main.go
+++ b/main.go
@@ -74,7 +74,7 @@ func main() {
 		for i := 0; i < *nodeCount; i++ {
 			// randomize the amount
 			if GlobalStressTest {
-				startingBalance = 10 + GetRandomNumber(startingBalance)
+				startingBalance = 10 + GetRandomNumber(1000)
 			}
 
 			sendRandomTransaction("dl", names[i], i+1, startingBalance, getNodeByAddress(names[i]))

--- a/node.go
+++ b/node.go
@@ -6,7 +6,7 @@ import (
 	logger "github.com/nic0lae/golog"
 )
 
-
+// StartListenForTx loops receiving transactions
 func (node *Node) StartListenForTx() {
 	logger.Instance().LogInfo(node.Wallet, 0, "StartListenForTx()")
 
@@ -44,6 +44,7 @@ func (node *Node) StartListenForTx() {
 	}()
 }
 
+// IsDoneProcessing returns true if node is idle
 func (node *Node) IsDoneProcessing() bool {
 	//if no transactions within 5 seconds consider done with transactions
 	var sec = time.Since(node.TimeForLastTx).Seconds()
@@ -68,9 +69,7 @@ func (node *Node) validateBlockAndTransmit(tx Transaction) {
 		node.TxFromChainById[tx.Id] = tx
 
 		// set the delegate id to current id and broadcast the valid transaction to other nodes
-		for k, _ := range getNodes() {
-
-			destinationNode := getNodes()[k]
+		for _, destinationNode := range getNodes() {
 			//don't send to self or Del that sent us the transaction
 			if destinationNode.Wallet == node.Wallet || destinationNode.Wallet == tx.DelId {
 				continue
@@ -83,13 +82,18 @@ func (node *Node) validateBlockAndTransmit(tx Transaction) {
 			//send transaction
 			go func(node *Node) {
 				tx.DelId = node.Wallet
+
+				if GlobalStressTest {
+					time.Sleep(time.Millisecond * time.Duration(GetRandomNumber(2000)))
+				}
+
 				destinationNode.TxChannel <- tx
 			}(destinationNode)
 		}
 	}
 }
 
-//validates the transaction and adds it to the end of the chain
+// validates the transaction and adds it to the end of the chain
 func (node *Node) validate(tx Transaction) bool {
 
 	//logger.Instance().LogInfo(node.Wallet, 3, "validate()")

--- a/node.go
+++ b/node.go
@@ -59,13 +59,13 @@ func (node *Node) checkIfValidated(txId int) bool {
 }
 
 func (node *Node) validateBlockAndTransmit(tx Transaction) {
-	//logger.Instance().LogInfo(node.Wallet, 2, "validateBlockAndTransmit()")
+	// logger.Instance().LogInfo(node.Wallet, 2, "validateBlockAndTransmit()")
 
-	//call Validate(transaction)
+	// call Validate(transaction)
 	valid := node.validate(tx)
 
 	if valid {
-		//add to seen list
+		// add to seen list
 		node.TxFromChainById[tx.Id] = tx
 
 		// set the delegate id to current id and broadcast the valid transaction to other nodes
@@ -79,7 +79,7 @@ func (node *Node) validateBlockAndTransmit(tx Transaction) {
 			//	fmt.Sprintf("sendTx() | Tx_%d(%s -> %d -> %s) | SentBy: %s | SendingTo: %s", tx.Id, tx.From, tx.Value, tx.To, tx.DelId, destinationNode.Wallet),
 			//)
 
-			//send transaction
+			// send transaction
 			go func(node *Node) {
 				tx.DelId = node.Wallet
 
@@ -87,7 +87,7 @@ func (node *Node) validateBlockAndTransmit(tx Transaction) {
 					time.Sleep(time.Millisecond * time.Duration(GetRandomNumber(2000)))
 				}
 
-				destinationNode.TxChannel <- tx
+				node.TxChannel <- tx
 			}(destinationNode)
 		}
 	}
@@ -95,7 +95,6 @@ func (node *Node) validateBlockAndTransmit(tx Transaction) {
 
 // validates the transaction and adds it to the end of the chain
 func (node *Node) validate(tx Transaction) bool {
-
 	//logger.Instance().LogInfo(node.Wallet, 3, "validate()")
 
 	var isTxValid = false

--- a/structures.go
+++ b/structures.go
@@ -5,12 +5,14 @@ import (
 	"time"
 )
 
+// Block contains a transaction and links to prev/next blocks
 type Block struct {
 	Prev        *Block
 	Next        *Block
 	Transaction Transaction
 }
 
+// Transaction contains a transaction
 type Transaction struct {
 	Id    int
 	From  string
@@ -20,6 +22,7 @@ type Transaction struct {
 	DelId string
 }
 
+// Node contains wallets and blockchain
 type Node struct {
 	GenesisBlock Block
 	LastBlock    *Block


### PR DESCRIPTION
You'll notice some minor formatting differences caused by VSCode.  Are you guys using special settings?  Or not formatting on save? We need to get in sync so we don't have little differences.

Also, my VSCode linter was complaining about needing comments above any exported vars or funcs, so I added some just to get rid of those. The linter also complains about using "Id" instead of "ID", but I left that alone.  It would be nice to get that fixed to have zero warnings.

Added a -stress=true flag which makes it fail every time

Also, found a little bug in the code that puzzled me for a while until I found it.

node.go

go func(node *Node) {
				tx.DelId = node.Wallet

				if GlobalStressTest {
					time.Sleep(time.Millisecond * time.Duration(GetRandomNumber(2000)))
				}

// ====>   node.TxChannel was previously destinationNode.TxChannel which worked only because you were making a local variable, but caused a bug when I added for _, destionationNode In any case, it should have used the func param rather than the outer var.

				node.TxChannel <- tx
			}(destinationNode)
